### PR TITLE
[STYLE] 멤버, 검색 화면의 좌측 메뉴 1개 미노출

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,10 @@
         </v-col>
       </v-row>
       <v-row no-gutters style="height: 100%">
-        <v-col cols="2" v-if="!isHiddenPage">
+        <v-col
+          :cols="!isInnerMenuOnlyOutsidePage ? 2 : 'auto'"
+          v-if="!isHiddenPage"
+        >
           <div class="d-flex innerMenuContainer">
             <InnerMenu v-if="!isHiddenPage" />
           </div>
@@ -36,9 +39,15 @@ export default {
     },
     isHiddenPage() {
       // 보이지 않아야 할 페이지 목록
-      const hiddenPages = ["/login", "/","/invite"];
+      const hiddenPages = ["/login", "/", "/invite"];
       // 현재 경로가 목록에 포함되어 있는지 확인
       return hiddenPages.includes(this.$route.path);
+    },
+    isInnerMenuOnlyOutsidePage() {
+      // 좌측 메뉴 중 1번째 메뉴만 보이는 화면인지 확인 (좌측메뉴 사이즈 조정용)
+      // router 이름으로 검색
+      const routePageNames = ["SEARCH", "MemberView"];
+      return routePageNames.includes(this.$route.name);
     },
   },
   name: "App",
@@ -51,8 +60,7 @@ export default {
       workspaceInfo: [],
     };
   },
-  methods: {
-  },
+  methods: {},
 };
 </script>
 

--- a/src/components/basic/InnerMenu.vue
+++ b/src/components/basic/InnerMenu.vue
@@ -82,10 +82,10 @@
     v-if="selectedMenu === 'home'"
     :selectedValue="selectedValue"
   />
-  <InnerRelatedMenuMember
+  <!-- <InnerRelatedMenuMember
     v-if="selectedMenu === 'member'"
     :selectedValue="selectedValue"
-  />
+  /> -->
 </template>
 
 <script>
@@ -93,7 +93,7 @@ import axios from "axios";
 import { mapGetters, mapActions } from "vuex";
 
 import InnerRelatedMenuHome from "@/components/basic/InnerRelatedMenuHome.vue";
-import InnerRelatedMenuMember from "@/components/basic/InnerRelatedMenuMember.vue";
+// import InnerRelatedMenuMember from "@/components/basic/InnerRelatedMenuMember.vue";
 import ModalProfileLogout from "@/views/member/ModalProfileLogout.vue"; // 모달 컴포넌트 import
 import CreateWorkspaceModal from "@/components/basic/CreateWorkspaceModal.vue";
 
@@ -114,7 +114,7 @@ export default {
   name: "InnerMenu",
   components: {
     InnerRelatedMenuHome,
-    InnerRelatedMenuMember,
+    // InnerRelatedMenuMember,
     ModalProfileLogout,
     CreateWorkspaceModal,
   },


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 공통 컴포넌트 버튼 작업, 프로젝트 페이지 제작 -->
1.  멤버, 검색 화면의 좌측 메뉴 1개 미노출 하도록 변경

## 📷 결과 화면
<!-- 만든 화면을 캡처해주세요 -->

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/HC-1  -->
feat/edit-home-login